### PR TITLE
Stable-er paged table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
   ],
+  plugins: ['react-hooks'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/react",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6080,9 +6080,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz",
+      "integrity": "sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -9549,6 +9549,12 @@
               "dev": true
             }
           }
+        },
+        "eslint-plugin-react-hooks": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+          "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+          "dev": true
         },
         "eslint-scope": {
           "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/react",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "module": "build/index.js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "axios": "^0.19.0",
     "eslint": "^6.3.0",
     "eslint-config-react-app": "^5.0.1",
+    "eslint-plugin-react-hooks": "^2.0.1",
     "husky": "^2.4.1",
     "jetbridge-react-scripts": "latest",
     "lint-staged": "^8.1.7",

--- a/src/table/pagedTable/pagedTable.tsx
+++ b/src/table/pagedTable/pagedTable.tsx
@@ -150,42 +150,44 @@ function usePagedTable<T>(props: IUsePagedTableProps<T>): IPagedTableHook<T> {
   // our PagedDataContext
   const pagedDataContext = React.useMemo(() => ({ reloadData: loadAPI }), [loadAPI])
 
-  // does useMemo help here at all?
-  return React.useMemo(
+  const renderProps = React.useMemo<IDefaultPagedTableImpl<T>>(
     () => ({
-      isLoading,
-      reloadData: loadAPI,
-      totalRows,
-      page,
-      renderProps: {
-        rows,
-        page,
-        setPage,
-        pageSize,
-        setPageSize,
-        totalRows,
-        isLoading,
-        handleChangePage,
-        pagedDataContext,
-        handleChangeRowsPerPage,
-        setTotalRows,
-      },
-    }),
-    [
-      isLoading,
-      loadAPI,
       rows,
       page,
       setPage,
       pageSize,
       setPageSize,
       totalRows,
+      isLoading,
       handleChangePage,
       pagedDataContext,
       handleChangeRowsPerPage,
       setTotalRows,
-    ]
+    }),
+    []
   )
+
+  // construct initial independent retVal that remains stable even if fields inside change
+  const retVal = React.useMemo<IPagedTableHook<T>>(
+    () => ({
+      isLoading: false,
+      reloadData: () => {},
+      renderProps,
+      totalRows: 0,
+      page: 0,
+    }),
+    []
+  )
+
+  // fill in fields of retVal
+  retVal.isLoading = isLoading
+  retVal.reloadData = loadAPI
+  retVal.totalRows = totalRows
+  retVal.page = page
+
+  retVal.renderProps = renderProps
+
+  return retVal
 }
 
 export default usePagedTable

--- a/src/table/pagedTable/pagedTable.tsx
+++ b/src/table/pagedTable/pagedTable.tsx
@@ -150,6 +150,7 @@ function usePagedTable<T>(props: IUsePagedTableProps<T>): IPagedTableHook<T> {
   // our PagedDataContext
   const pagedDataContext = React.useMemo(() => ({ reloadData: loadAPI }), [loadAPI])
 
+  // construct
   const renderProps = React.useMemo<IDefaultPagedTableImpl<T>>(
     () => ({
       rows,
@@ -164,7 +165,19 @@ function usePagedTable<T>(props: IUsePagedTableProps<T>): IPagedTableHook<T> {
       handleChangeRowsPerPage,
       setTotalRows,
     }),
-    []
+    [
+      rows,
+      page,
+      setPage,
+      pageSize,
+      setPageSize,
+      totalRows,
+      isLoading,
+      handleChangePage,
+      pagedDataContext,
+      handleChangeRowsPerPage,
+      setTotalRows,
+    ]
   )
 
   // construct initial independent retVal that remains stable even if fields inside change
@@ -184,7 +197,6 @@ function usePagedTable<T>(props: IUsePagedTableProps<T>): IPagedTableHook<T> {
   retVal.reloadData = loadAPI
   retVal.totalRows = totalRows
   retVal.page = page
-
   retVal.renderProps = renderProps
 
   return retVal


### PR DESCRIPTION
Problem: the object returned from `usePagedTable()` changes all the time, so if it's used as a dependency then it causes things to re-render all the time. If used in a component that renders the table rows, eslint tries to enforce `pagedTable` as a dependency of an apiCall, causing a circular dependency loading the API over and over.

My proposed solution is to create a memoized return value once, with no dependencies, and then update the fields inside of it as they change. Because dependencies are shallowly compared, I believe this will make the table more easy to use a dependency.