### PR TITLE
add params sorting

### DIFF
--- a/src/apiClient/paginated.ts
+++ b/src/apiClient/paginated.ts
@@ -23,6 +23,11 @@ export interface IPaginatedRequest {
   queryParams?: object
 }
 
+const sortParams = (params: object) =>
+  Object.keys(params)
+    .sort()
+    .reduce((a, c) => ((a[c] = params[c]), a), {})
+
 /**
  * Returns a function that performs a paginated API request.
  */
@@ -34,7 +39,7 @@ export const requestPaginated = <ResponseT>({ url, method = 'get' }: IAPIDescrip
 
   // construct pagination params
   const paginationParams = { page: paginatedRequest.page, page_size: paginatedRequest.pageSize }
-  const response = await apiClient.get<ResponseT>(url, { params: { ...paginationParams, ...queryParams } })
+  const response = await apiClient.get<ResponseT>(url, { params: sortParams({ ...paginationParams, ...queryParams }) })
 
   // pagination info lives in response header
 


### PR DESCRIPTION
The reason it's needed is to have stable params for stubbing responses for tests.