### PR TITLE
Auth Response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/react",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "module": "build/index.js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "module": "build/index.js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/apiClient/index.ts
+++ b/src/apiClient/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { useAuthTokenInterceptor } from 'axios-jwt'
+import { useAuthTokenInterceptor, setAuthTokens } from 'axios-jwt'
 import { IAuthTokens, TokenRefreshRequest, refreshTokenIfNeeded as ajwtRefreshTokenIfNeeded } from 'axios-jwt'
 
 // https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables
@@ -46,6 +46,16 @@ export const authResponseToAuthTokens = (res: IAuthResponse): IAuthTokens => ({
   accessToken: res.access_token,
   refreshToken: res.refresh_token,
 })
+
+/**
+ * Process an AuthResponse from auth API and save JWT.
+ */
+export const setAuthTokensFromAuthResponse = async (res: IAuthResponse) => {
+  // transform auth API response
+  const tokenRes = authResponseToAuthTokens(res)
+  setAuthTokens(tokenRes)
+  return tokenRes
+}
 
 export const requestRefresh: TokenRefreshRequest = async (refreshToken: string): Promise<string> => {
   // perform refresh

--- a/src/errorHandler/index.ts
+++ b/src/errorHandler/index.ts
@@ -4,6 +4,8 @@ import notify from '../snackbarCustom/notify'
 export const handleError = (error: AxiosError, resourceName?: string) => {
   let message = 'Something went wrong. Please try again later.'
 
+  console.error(error)
+
   const response = error.response
   if (response) {
     if (response.status === 401) {

--- a/src/errorHandler/index.ts
+++ b/src/errorHandler/index.ts
@@ -3,17 +3,18 @@ import notify from '../snackbarCustom/notify'
 
 export const handleError = (error: AxiosError, resourceName?: string) => {
   let message = 'Something went wrong. Please try again later.'
+
   const response = error.response
   if (response) {
     if (response.status === 401) {
-      message = "Unauthorized request"
+      message = 'Unauthorized request'
     }
     if (response.status === 404) {
       message = `${resourceName || 'Resource'} not found`
     } else if (response.data) {
       message = response.data.message
     }
-    if (response.status === 422) {
+    if (response.status === 422 && response.data.errors) {
       const key = Object.keys(response.data.errors)[0]
       message = response.data.errors[key][0]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import { handleError } from './errorHandler/index'
 import { IPaginatedRequest, IPaginatedResponse } from './apiClient/paginated'
 import { IMenuSection } from './types'
-import { apiClient, requestRefresh, refreshTokenIfNeeded } from './apiClient/index'
+import {
+  apiClient,
+  requestRefresh,
+  refreshTokenIfNeeded,
+  IAuthResponse,
+  setAuthTokensFromAuthResponse,
+} from './apiClient/index'
 import LoginScreen from './LoginScreen'
 import Menu from './menu'
 import authService from './service/auth'
@@ -35,6 +41,7 @@ export {
   useSnackbar,
   notify,
   UseSnackbarUI,
+  TextFieldWithDebounce,
   usePagedTable,
   PagedTable,
   IPaginatedRequest,
@@ -45,6 +52,9 @@ export {
   IPagedTableImpl,
   IPagedTableProps,
   PagedDataContext,
+  toTitleCase,
+  // authentication
+  IAuthResponse,
   requestRefresh,
   PrivateRoute,
   refreshTokenIfNeeded,
@@ -52,8 +62,7 @@ export {
   getAccessToken,
   isLoggedIn,
   clearAuthTokens,
-  TextFieldWithDebounce,
-  toTitleCase,
+  setAuthTokensFromAuthResponse,
   // asset
   UploadFileToS3Args,
   UploadRequest,


### PR DESCRIPTION
Provide a very simple bridge between our backend AuthResponse and axios-jwt (basically just snake ⇾ camel) and make it simpler to implement auth/signup/etc

Log errors passed to handleError to console and check if we actually have the error object shape we expect

A little sorting in exports

