### PR TITLE
Add useEventual hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetkit/react",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "module": "build/index.js",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@material-ui/icons": "^3.0.2",
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^8.0.4",
+    "@testing-library/react-hooks": "^3.2.1",
     "@types/classnames": "^2.2.9",
     "@types/jest": "^24.0.13",
     "@types/jsonwebtoken": "^8.3.2",
@@ -92,7 +93,8 @@
     "lint-staged": "^8.1.7",
     "prettier": "^1.17.1",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "react-test-renderer": "^16.9.0"
   },
   "files": [
     "build"

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import AssetUpload, { IAssetUpload } from './form/assetUpload'
 import FileDropzone, { IFileDropzoneProps } from './form/fileDropzone'
 import { useDropzone } from './form/fileDropzone/useFileDropzone'
 import toTitleCase from './toTitleCase'
+import { useEventual } from './useEventual/index'
 
 export {
   LoginScreen,
@@ -75,4 +76,5 @@ export {
   useDropzone,
   SmoothPagedTable,
   useSmoothPagedTable,
+  useEventual,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,5 @@ export interface IMenuSection {
   expanded?: boolean
   icon?: any //TODO: FIX ANY!
 }
+
+export type Eventual<T> = { loading: true } | { loading: false; value: T }

--- a/src/useAsyncEffect/index.ts
+++ b/src/useAsyncEffect/index.ts
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+export const useAsyncEffect = (callback: () => Promise<unknown>, deps?: React.DependencyList) => {
+  React.useEffect(() => {
+    callback()
+  }, deps)
+}

--- a/src/useEventual/index.test.ts
+++ b/src/useEventual/index.test.ts
@@ -1,0 +1,51 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useEventual } from './index'
+
+const mockPromise = <T>() => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = () => {}
+  const promise = new Promise<T>(_resolve => {
+    resolve = _resolve
+  })
+
+  return { promise, resolve }
+}
+
+test(`only the last promise's value is used`, async () => {
+  const promise1 = mockPromise<string>()
+  const promise2 = mockPromise<string>()
+  const promise3 = mockPromise<string>()
+
+  // Hook will update only when dependencies change, not the promise itself, so we have to pass
+  // something unique in deps each time we want to see a change.
+  const { result, rerender } = renderHook(({ promise, id }) => useEventual(() => promise, [id]), {
+    initialProps: { promise: promise1.promise, id: 1 },
+  })
+
+  // Hook will return {loading: true} until the most recet promise is resolved
+  expect(result.current).toEqual({ loading: true })
+
+  rerender({ promise: promise2.promise, id: 2 })
+  expect(result.current).toEqual({ loading: true })
+
+  rerender({ promise: promise3.promise, id: 3 })
+  expect(result.current).toEqual({ loading: true })
+
+  // Resolving promises in random order
+  // First one is ignored because hook waits for more recent promise to resolve
+  await act(async () => {
+    promise1.resolve('result1')
+  })
+  expect(result.current).toEqual({ loading: true })
+
+  // Third one is used because it was passed to the hook last
+  await act(async () => {
+    promise3.resolve('result3')
+  })
+  expect(result.current).toEqual({ loading: false, value: 'result3' })
+
+  // Second one is ignored because more recent promise was used already
+  await act(async () => {
+    promise2.resolve('result2')
+  })
+  expect(result.current).toEqual({ loading: false, value: 'result3' })
+})

--- a/src/useEventual/index.ts
+++ b/src/useEventual/index.ts
@@ -10,7 +10,7 @@ import { useAsyncEffect } from '../useAsyncEffect'
  * Typechecker will make sure that you do not accidentally use a value that is not there yet.
  *
  * This hook keeps track of the order in which promises were invoked
- * (this happens each time the dependencies change), and updates the value only when the last
+ * (this happens each time the dependencies change), and updates the value only when the most recet
  * promise resolves. Until then, `{loading: true}` will be returned.
  *
  * @param dataSource Function that returns a promise which resolves to a desired value.
@@ -19,6 +19,13 @@ import { useAsyncEffect } from '../useAsyncEffect'
  */
 export const useEventual = <T>(dataSource: () => Promise<T>, deps: React.DependencyList = []): Eventual<T> => {
   const [state, setState] = React.useState<Eventual<T>>({ loading: true })
+  // `stateVersion` keeps track of how many different promises were passed to this hook.
+  // On each new promise the stateVersion is bumped and is attached to the promise.
+  // When a promise resolves, it's version is compared to the currently expected version,
+  // and promise's value is used only when the versions match. If they don't, that means there's a
+  // more recent promise that should be used.
+  // This helps to achieve a behavior where only the most recent promise is used, regardless of the
+  // order in which they resolve.
   const stateVersion = React.useRef(0)
 
   const incrementVersion = React.useCallback(() => (stateVersion.current = stateVersion.current + 1), [])

--- a/src/useEventual/index.ts
+++ b/src/useEventual/index.ts
@@ -28,7 +28,7 @@ export const useEventual = <T>(dataSource: () => Promise<T>, deps: React.Depende
   // order in which they resolve.
   const stateVersion = React.useRef(0)
 
-  const incrementVersion = React.useCallback(() => (stateVersion.current = stateVersion.current + 1), [])
+  const incrementVersion = React.useCallback(() => ++stateVersion.current, [])
 
   useAsyncEffect(async () => {
     setState({ loading: true })

--- a/src/useEventual/index.ts
+++ b/src/useEventual/index.ts
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { Eventual } from '../types'
+import { useAsyncEffect } from '../useAsyncEffect'
 
 /**
  * Wraps a promise and returns a type-safe `Eventual` value that properly updates if dependencies change.
@@ -22,17 +23,17 @@ export const useEventual = <T>(dataSource: () => Promise<T>, deps: React.Depende
 
   const incrementVersion = React.useCallback(() => (stateVersion.current = stateVersion.current + 1), [])
 
-  React.useEffect(() => {
+  useAsyncEffect(async () => {
     setState({ loading: true })
     incrementVersion()
 
     const expectedVersion = stateVersion.current
 
-    dataSource().then(result => {
-      if (stateVersion.current === expectedVersion) {
-        setState({ loading: false, value: result })
-      }
-    })
+    const result = await dataSource()
+
+    if (stateVersion.current === expectedVersion) {
+      setState({ loading: false, value: result })
+    }
   }, deps)
 
   return state

--- a/src/useEventual/index.ts
+++ b/src/useEventual/index.ts
@@ -1,0 +1,39 @@
+import * as React from 'react'
+
+import { Eventual } from '../types'
+
+/**
+ * Wraps a promise and returns a type-safe `Eventual` value that properly updates if dependencies change.
+ *
+ * This hook has two possible return values: `{loading: true}` and `{loading: false, value}`.
+ * Typechecker will make sure that you do not accidentally use a value that is not there yet.
+ *
+ * This hook keeps track of the order in which promises were invoked
+ * (this happens each time the dependencies change), and updates the value only when the last
+ * promise resolves. Until then, `{loading: true}` will be returned.
+ *
+ * @param dataSource Function that returns a promise which resolves to a desired value.
+ * @param deps If present, returned value will be updated from the provided promise each
+ * time the values in the list change.
+ */
+export const useEventual = <T>(dataSource: () => Promise<T>, deps: React.DependencyList = []): Eventual<T> => {
+  const [state, setState] = React.useState<Eventual<T>>({ loading: true })
+  const stateVersion = React.useRef(0)
+
+  const incrementVersion = React.useCallback(() => (stateVersion.current = stateVersion.current + 1), [])
+
+  React.useEffect(() => {
+    setState({ loading: true })
+    incrementVersion()
+
+    const expectedVersion = stateVersion.current
+
+    dataSource().then(result => {
+      if (stateVersion.current === expectedVersion) {
+        setState({ loading: false, value: result })
+      }
+    })
+  }, deps)
+
+  return state
+}


### PR DESCRIPTION
I noticed a pattern in our frontend code and took the liberty of refactoring it into a reusable hook. This hook wraps a promise and provides a concise and type-safe API:

```tsx
const getuserById = (id: number) => apiClient
  .get<{data: User}>(`https://reqres.in/api/users/${id}`)
  .then(response => response.data.data)

const App: React.FC = () => {
  const [userId, setUserId] = useState(1)

  const user = useEventual(() => getuserById(userId), [userId])

  return (
    <div>
      {user.loading
        ? <span>Loading...</span>
        : <div>
          <span>Name: {user.value.first_name} {user.value.last_name}</span>
        </div>
      }
      <button onClick={() => setUserId(id => id + 1)}>Next user</button>
    </div>
  )
}
```

Thanks to TypeScript, you won't be able to shoot yourself in the foot:
```tsx
  const user = useEventual(() => getuserById(userId), [userId])

  console.log(user.value.firstName)   // fails typecheck

  if (user.loading) {
    console.log(user.value.firstName) // fails typecheck
  } else {
    console.log(user.value.firstName) // no error
  }
```

This is designed in such a way that if you spam this hook with multiple updates in a short period of time, there won't be a race between the promises, only the value from last invoked promise will be used, even if they resolve out of order. 