### PR TITLE
add file drag drop area

### DIFF
--- a/src/form/dragDropArea/index.tsx
+++ b/src/form/dragDropArea/index.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles({
+  root: {
+    height: '100vh',
+    width: '100%',
+  },
+})
+
+interface IDragDropAreaProps {
+  overlay: React.ReactElement
+  children: React.ReactElement
+  onFilesDrop: (files: File[]) => void
+}
+
+const DragDropArea = ({ overlay, children, onFilesDrop }: IDragDropAreaProps) => {
+  const classes = useStyles()
+  const [dragActive, setDragActive] = React.useState(0)
+
+  const onDragEnter = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setDragActive(prev => prev + 1)
+  }, [])
+
+  const onDragOver = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }, [])
+
+  const onDragLeave = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setDragActive(prev => prev - 1)
+  }, [])
+
+  const onDrop = React.useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      setDragActive(0)
+
+      if (event.nativeEvent.dataTransfer) {
+        const files = Array.from(event.nativeEvent.dataTransfer.files)
+        onFilesDrop(files)
+      }
+    },
+    [onFilesDrop]
+  )
+
+  return (
+    <div
+      className={classes.root}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {children}
+      {dragActive > 0 && overlay}
+    </div>
+  )
+}
+
+export default DragDropArea

--- a/src/form/dragDropArea/index.tsx
+++ b/src/form/dragDropArea/index.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react'
-import { makeStyles } from '@material-ui/core'
-
-const useStyles = makeStyles({
-  root: {
-    height: '100vh',
-    width: '100%',
-  },
-})
 
 interface IDragDropAreaProps {
   overlay: React.ReactElement
   children: React.ReactElement
   onFilesDrop: (files: File[]) => void
+  className?: string
 }
 
-const DragDropArea = ({ overlay, children, onFilesDrop }: IDragDropAreaProps) => {
-  const classes = useStyles()
+const DragDropArea = ({ overlay, children, onFilesDrop, className }: IDragDropAreaProps) => {
   const [dragActive, setDragActive] = React.useState(0)
 
   const onDragEnter = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -47,7 +39,7 @@ const DragDropArea = ({ overlay, children, onFilesDrop }: IDragDropAreaProps) =>
 
   return (
     <div
-      className={classes.root}
+      className={className}
       onDragEnter={onDragEnter}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import FileDropzone, { IFileDropzoneProps } from './form/fileDropzone'
 import { useDropzone } from './form/fileDropzone/useFileDropzone'
 import toTitleCase from './toTitleCase'
 import { useEventual } from './useEventual/index'
+import DragDropArea from './form/dragDropArea'
 
 export {
   LoginScreen,
@@ -77,4 +78,5 @@ export {
   SmoothPagedTable,
   useSmoothPagedTable,
   useEventual,
+  DragDropArea,
 }


### PR DESCRIPTION
Add a standalone wrapper component that creates a drag&drop file zone around the wrapped component. 

Props:
- `children` component
- `overlay` component that pops up on top of children when the file is being dragged over the area.
- `onFilesDrop` callback (it's up to the user what to do with it) 

Example:
![dragdrop](https://user-images.githubusercontent.com/9088821/83006437-8174ea80-a012-11ea-99a6-3d2cbd052410.gif)
