### PR TITLE
Fix `parseParams`

### DIFF
--- a/src/apiClient/index.ts
+++ b/src/apiClient/index.ts
@@ -16,7 +16,7 @@ const parseParams = (params: object) => {
 
   keys.forEach(key => {
     const isParamTypeObject = typeof params[key] === 'object'
-    const isParamTypeArray = isParamTypeObject && params[key].length >= 0
+    const isParamTypeArray = isParamTypeObject && params[key] && params[key].length >= 0
 
     if (!isParamTypeObject) {
       options += `${key}=${params[key]}&`


### PR DESCRIPTION
Was getting `TypeError: Cannot read property 'length' of null` exception. Added `null` handler in addition.

*What is strange is these errors were not shown in devtools.*